### PR TITLE
FEAT/calendar 조회 API 구현

### DIFF
--- a/server/src/main/java/com/rezero/inandout/calendar/controller/CalendarController.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/controller/CalendarController.java
@@ -1,0 +1,40 @@
+package com.rezero.inandout.calendar.controller;
+
+import com.rezero.inandout.calendar.model.CalendarMonthlyDto;
+import com.rezero.inandout.calendar.service.Impl.CalendarServiceImpl;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.security.Principal;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calendar")
+public class CalendarController {
+
+    private final CalendarServiceImpl calendarService;
+
+    @GetMapping
+    @ApiOperation(value = "달력화면의 수입&지출 내역 조회 API",
+        notes = "로그인 시 메인화면. 해당 회원의 한 달의 수입&지출 내역이 조회된다.")
+    public ResponseEntity<?> getCalendarIncomeAndExpenseList(Principal principal,
+                    @ApiParam(value = "조회 시작 날짜", example = "2022-01-01")
+                    @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDt,
+                    @ApiParam(value = "조회 끝 날짜", example = "2022-01-31")
+                    @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDt) {
+
+        CalendarMonthlyDto calendarMonthlyDto
+            = calendarService.getCalendarIncomeAndExpenseList(principal.getName(), startDt, endDt);
+
+        return ResponseEntity.ok(calendarMonthlyDto);
+    }
+
+}

--- a/server/src/main/java/com/rezero/inandout/calendar/model/CalendarExpenseDto.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/model/CalendarExpenseDto.java
@@ -1,0 +1,20 @@
+package com.rezero.inandout.calendar.model;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CalendarExpenseDto {
+    LocalDate expenseDt;
+
+    String item;
+    int amount;
+}

--- a/server/src/main/java/com/rezero/inandout/calendar/model/CalendarIncomeDto.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/model/CalendarIncomeDto.java
@@ -1,0 +1,21 @@
+package com.rezero.inandout.calendar.model;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CalendarIncomeDto {
+    LocalDate incomeDt;
+
+    String item;
+    int amount;
+
+}

--- a/server/src/main/java/com/rezero/inandout/calendar/model/CalendarMonthlyDto.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/model/CalendarMonthlyDto.java
@@ -1,0 +1,22 @@
+package com.rezero.inandout.calendar.model;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CalendarMonthlyDto {
+    int year;
+    int month;
+
+    List<CalendarIncomeDto> calendarIncomeDtoList;
+    List<CalendarExpenseDto> calendarExpenseDtoList;
+
+}

--- a/server/src/main/java/com/rezero/inandout/calendar/service/CalendarService.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/service/CalendarService.java
@@ -1,0 +1,10 @@
+package com.rezero.inandout.calendar.service;
+
+import com.rezero.inandout.calendar.model.CalendarMonthlyDto;
+import java.time.LocalDate;
+
+public interface CalendarService {
+
+    CalendarMonthlyDto getCalendarIncomeAndExpenseList(String email, LocalDate startDt, LocalDate endDt);
+
+}

--- a/server/src/main/java/com/rezero/inandout/calendar/service/Impl/CalendarServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/calendar/service/Impl/CalendarServiceImpl.java
@@ -1,0 +1,36 @@
+package com.rezero.inandout.calendar.service.Impl;
+
+import com.rezero.inandout.calendar.model.CalendarExpenseDto;
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
+import com.rezero.inandout.calendar.model.CalendarMonthlyDto;
+import com.rezero.inandout.calendar.service.CalendarService;
+import com.rezero.inandout.expense.service.base.impl.ExpenseServiceImpl;
+import com.rezero.inandout.income.service.base.impl.IncomeServiceImpl;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarServiceImpl implements CalendarService {
+
+    private final IncomeServiceImpl incomeService;
+    private final ExpenseServiceImpl expenseService;
+
+    @Override
+    public CalendarMonthlyDto getCalendarIncomeAndExpenseList(String email, LocalDate startDt, LocalDate endDt) {
+
+        List<CalendarIncomeDto> calendarIncomeDtoList
+            = incomeService.getMonthlyIncomeCalendar(email, startDt, endDt);
+        List<CalendarExpenseDto> calendarExpenseDtoList
+            = expenseService.getMonthlyExpenseCalendar(email, startDt, endDt);
+
+        return CalendarMonthlyDto.builder()
+            .year(startDt.getYear())
+            .month(startDt.getMonthValue())
+            .calendarIncomeDtoList(calendarIncomeDtoList)
+            .calendarExpenseDtoList(calendarExpenseDtoList)
+            .build();
+    }
+}

--- a/server/src/main/java/com/rezero/inandout/expense/service/base/ExpenseService.java
+++ b/server/src/main/java/com/rezero/inandout/expense/service/base/ExpenseService.java
@@ -1,5 +1,6 @@
 package com.rezero.inandout.expense.service.base;
 
+import com.rezero.inandout.calendar.model.CalendarExpenseDto;
 import com.rezero.inandout.expense.model.DeleteExpenseInput;
 import com.rezero.inandout.expense.model.ExpenseCategoryDto;
 import com.rezero.inandout.expense.model.ExpenseDto;
@@ -25,4 +26,6 @@ public interface ExpenseService {
     List<ReportDto> getMonthlyExpenseReport(String email, LocalDate startDt, LocalDate endDt);
 
     List<YearlyExpenseReportDto> getYearlyExpenseReport(String email, LocalDate startDt, LocalDate endDt);
+
+    List<CalendarExpenseDto> getMonthlyExpenseCalendar(String email, LocalDate startDt, LocalDate endDt);
 }

--- a/server/src/main/java/com/rezero/inandout/expense/service/base/impl/ExpenseServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/expense/service/base/impl/ExpenseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.rezero.inandout.expense.service.base.impl;
 
+import com.rezero.inandout.calendar.model.CalendarExpenseDto;
 import com.rezero.inandout.exception.ExpenseException;
 import com.rezero.inandout.exception.errorcode.ExpenseErrorCode;
 import com.rezero.inandout.expense.entity.DetailExpenseCategory;
@@ -196,6 +197,13 @@ public class ExpenseServiceImpl implements ExpenseService {
         }
 
         return yearlyReportDtos;
+    }
+
+    @Override
+    public List<CalendarExpenseDto> getMonthlyExpenseCalendar(String email, LocalDate startDt, LocalDate endDt) {
+        Member member = findMemberByEmail(email);
+
+        return expenseQueryRepository.getMonthlyExpenseCalendar(member.getMemberId(), startDt, endDt);
     }
 
     private Expense findExpenseByExpenseId(Long expenseId) {

--- a/server/src/main/java/com/rezero/inandout/income/repository/IncomeQueryRepository.java
+++ b/server/src/main/java/com/rezero/inandout/income/repository/IncomeQueryRepository.java
@@ -2,6 +2,7 @@ package com.rezero.inandout.income.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
 import com.rezero.inandout.income.entity.QDetailIncomeCategory;
 import com.rezero.inandout.income.entity.QIncome;
 import com.rezero.inandout.income.entity.QIncomeCategory;
@@ -57,4 +58,16 @@ public class IncomeQueryRepository {
 
     }
 
+    public List<CalendarIncomeDto> getMonthlyIncomeCalendar(Long id, LocalDate startDt, LocalDate endDt) {
+
+        return queryFactory
+            .select(Projections.constructor(CalendarIncomeDto.class,
+                income.incomeDt, income.incomeItem, income.incomeAmount))
+            .from(income)
+            .where(income.member.memberId.eq(id)
+                .and(income.incomeDt.between(startDt, endDt)))
+            .orderBy(income.incomeDt.asc())
+            .fetch();
+
+    }
 }

--- a/server/src/main/java/com/rezero/inandout/income/service/base/IncomeService.java
+++ b/server/src/main/java/com/rezero/inandout/income/service/base/IncomeService.java
@@ -1,6 +1,7 @@
 package com.rezero.inandout.income.service.base;
 
 
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
 import com.rezero.inandout.income.model.DeleteIncomeInput;
 import com.rezero.inandout.income.model.DetailIncomeCategoryDto;
 import com.rezero.inandout.income.model.IncomeCategoryDto;
@@ -23,5 +24,8 @@ public interface IncomeService {
 
     List<ReportDto> getMonthlyIncomeReport(String email, LocalDate startDt, LocalDate endDt);
     List<YearlyIncomeReportDto> getYearlyIncomeReport(String email, LocalDate startDt, LocalDate endDt);
+
+
+    List<CalendarIncomeDto> getMonthlyIncomeCalendar(String email, LocalDate startDt, LocalDate endDt);
 
 }

--- a/server/src/main/java/com/rezero/inandout/income/service/base/impl/IncomeServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/income/service/base/impl/IncomeServiceImpl.java
@@ -5,6 +5,7 @@ import static com.rezero.inandout.exception.errorcode.IncomeErrorCode.NO_CATEGOR
 import static com.rezero.inandout.exception.errorcode.IncomeErrorCode.NO_INCOME;
 import static com.rezero.inandout.exception.errorcode.IncomeErrorCode.NO_MEMBER;
 
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
 import com.rezero.inandout.exception.IncomeException;
 import com.rezero.inandout.income.entity.DetailIncomeCategory;
 import com.rezero.inandout.income.entity.Income;
@@ -202,6 +203,13 @@ public class IncomeServiceImpl implements IncomeService {
         }
 
         return yearlyReportDtoList;
+    }
+
+    @Override
+    public List<CalendarIncomeDto> getMonthlyIncomeCalendar(String email, LocalDate startDt, LocalDate endDt) {
+        Member member = findMemberByEmail(email);
+
+        return incomeQueryRepository.getMonthlyIncomeCalendar(member.getMemberId(), startDt, endDt);
     }
 
 

--- a/server/src/main/resources/application-dbsecret.properties
+++ b/server/src/main/resources/application-dbsecret.properties
@@ -1,0 +1,4 @@
+# deploy
+spring.datasource.url=jdbc:mysql://3.34.206.181:3306/inandoutTest
+spring.datasource.username=inandout
+spring.datasource.password=inandout

--- a/server/src/test/java/com/rezero/inandout/calendar/controller/CalendarControllerTest.java
+++ b/server/src/test/java/com/rezero/inandout/calendar/controller/CalendarControllerTest.java
@@ -1,0 +1,109 @@
+package com.rezero.inandout.calendar.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rezero.inandout.calendar.model.CalendarExpenseDto;
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
+import com.rezero.inandout.calendar.model.CalendarMonthlyDto;
+import com.rezero.inandout.calendar.service.Impl.CalendarServiceImpl;
+import com.rezero.inandout.member.entity.Member;
+import com.rezero.inandout.member.service.MemberService;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.test.web.servlet.MockMvc;
+
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(CalendarController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("CalendarController 테스트")
+class CalendarControllerTest {
+
+    @MockBean
+    CalendarServiceImpl calendarService;
+
+    @MockBean
+    MemberService memberService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("달력화면의 수입&지출 내역 조회")
+    void getCalendarIncomeAndExpenseList() throws Exception {
+        //given
+        Member member = Member.builder()
+            .memberId(1L)
+            .email("hgd@gmail.com")
+            .password("1234")
+            .build();
+
+        User user = new User(member.getEmail(), member.getPassword(),
+            AuthorityUtils.createAuthorityList("ROLE_USER"));
+        TestingAuthenticationToken testingAuthenticationToken = new TestingAuthenticationToken(user,null);
+
+        List<CalendarIncomeDto> calendarIncomeDtoList = new ArrayList<>(Arrays.asList(
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 2))
+                .item("수입1").amount(123456).build(),
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 28))
+                .item("수입2").amount(54321).build()
+        ));
+
+        List<CalendarExpenseDto> calendarExpenseDtoList = new ArrayList<>(Arrays.asList(
+            CalendarExpenseDto.builder().expenseDt(LocalDate.of(2022, 10, 2))
+                .item("지출1").amount(98765).build(),
+            CalendarExpenseDto.builder().expenseDt(LocalDate.of(2022, 10, 16))
+                .item("지출2").amount(45678).build()
+        ));
+
+        CalendarMonthlyDto calendarMonthlyDto = CalendarMonthlyDto.builder()
+            .year(2022).month(10)
+            .calendarIncomeDtoList(calendarIncomeDtoList)
+            .calendarExpenseDtoList(calendarExpenseDtoList)
+            .build();
+
+        given(calendarService.getCalendarIncomeAndExpenseList(any(), any(), any()))
+            .willReturn(calendarMonthlyDto);
+
+        //when
+        mockMvc.perform(get("/api/calendar?startDt=2020-10-01&endDt=2020-10-31")
+                .principal(testingAuthenticationToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.year")
+                                .value(calendarMonthlyDto.getYear()))
+            .andExpect(jsonPath("$.month")
+                                .value(calendarMonthlyDto.getMonth()))
+            .andExpect(jsonPath("$.calendarIncomeDtoList[0].item")
+                                .value(calendarIncomeDtoList.get(0).getItem()))
+            .andExpect(jsonPath("$.calendarExpenseDtoList[1].amount")
+                                .value(calendarExpenseDtoList.get(1).getAmount()))
+            .andDo(print());
+
+        //then
+        verify(calendarService, times(1)).getCalendarIncomeAndExpenseList(any(), any(), any());
+
+    }
+
+}

--- a/server/src/test/java/com/rezero/inandout/calendar/service/Impl/CalendarServiceImplTest.java
+++ b/server/src/test/java/com/rezero/inandout/calendar/service/Impl/CalendarServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.rezero.inandout.calendar.service.Impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.rezero.inandout.calendar.model.CalendarExpenseDto;
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
+import com.rezero.inandout.calendar.model.CalendarMonthlyDto;
+import com.rezero.inandout.expense.service.base.impl.ExpenseServiceImpl;
+import com.rezero.inandout.income.service.base.impl.IncomeServiceImpl;
+import com.rezero.inandout.member.service.MemberService;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarServiceImplTest {
+
+    @Mock
+    private IncomeServiceImpl incomeService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private ExpenseServiceImpl expenseService;
+
+    @InjectMocks
+    private CalendarServiceImpl calendarService;
+
+    @Nested
+    @DisplayName("달력 수입&지출 조회 서비스 테스트")
+    class getMonthlyIncomeCalendarMethod {
+
+        List<CalendarIncomeDto> calendarIncomeDtoList = new ArrayList<>(Arrays.asList(
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 2))
+                .item("수입1").amount(123456).build(),
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 28))
+                .item("수입2").amount(54321).build()
+        ));
+
+        List<CalendarExpenseDto> calendarExpenseDtoList = new ArrayList<>(Arrays.asList(
+            CalendarExpenseDto.builder().expenseDt(LocalDate.of(2022, 10, 2))
+                .item("지출1").amount(98765).build(),
+            CalendarExpenseDto.builder().expenseDt(LocalDate.of(2022, 10, 16))
+                .item("지출2").amount(45678).build()
+        ));
+
+        CalendarMonthlyDto calendarMonthlyDto = CalendarMonthlyDto.builder()
+            .year(2022).month(10)
+            .calendarIncomeDtoList(calendarIncomeDtoList)
+            .calendarExpenseDtoList(calendarExpenseDtoList)
+            .build();
+
+        @Test
+        @DisplayName("성공")
+        void getMonthlyIncomeCalendar() {
+            //given
+            given(incomeService.getMonthlyIncomeCalendar(any(), any(), any()))
+                .willReturn(calendarIncomeDtoList);
+            given(expenseService.getMonthlyExpenseCalendar(any(), any(), any()))
+                .willReturn(calendarExpenseDtoList);
+
+            //when
+            CalendarMonthlyDto getCalendarMonthlyDto
+                = calendarService.getCalendarIncomeAndExpenseList(
+                    "test@naver.com",
+                        LocalDate.of(2022, 10, 1),
+                        LocalDate.of(2022, 10, 31)
+            );
+
+            //then
+            verify(incomeService, times(1))
+                .getMonthlyIncomeCalendar(any(), any(), any());
+            verify(expenseService, times(1))
+                .getMonthlyExpenseCalendar(any(), any(), any());
+
+            assertEquals(getCalendarMonthlyDto.getMonth(), calendarMonthlyDto.getMonth());
+            assertEquals(getCalendarMonthlyDto.getCalendarIncomeDtoList(), calendarIncomeDtoList);
+        }
+
+    }
+}

--- a/server/src/test/java/com/rezero/inandout/income/service/IncomeServiceImplTest.java
+++ b/server/src/test/java/com/rezero/inandout/income/service/IncomeServiceImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.rezero.inandout.calendar.model.CalendarIncomeDto;
 import com.rezero.inandout.exception.IncomeException;
 import com.rezero.inandout.exception.errorcode.IncomeErrorCode;
 import com.rezero.inandout.income.entity.DetailIncomeCategory;
@@ -738,6 +739,66 @@ class IncomeServiceImplTest {
             //then
             assertEquals(exception.getErrorCode(), NO_MEMBER);
         }
+    }
+
+    @Nested
+    @DisplayName("달력 수입 조회 서비스 테스트")
+    class getMonthlyIncomeCalendarMethod {
+
+        Member member = Member.builder()
+            .memberId(1L)
+            .password("1234")
+            .email("test@naver.com")
+            .build();
+
+        List<CalendarIncomeDto> calendarIncomeDtoList = new ArrayList<>(Arrays.asList(
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 2))
+                .item("수입1").amount(123456).build(),
+            CalendarIncomeDto.builder().incomeDt(LocalDate.of(2022, 10, 28))
+                .item("수입2").amount(54321).build()
+        ));
+
+        @Test
+        @DisplayName("성공")
+        void getMonthlyIncomeCalendar_success() {
+            //given
+            given(memberRepository.findByEmail(any()))
+                .willReturn(Optional.of(member));
+
+            given(incomeQueryRepository.getMonthlyIncomeCalendar(any(), any(), any()))
+                .willReturn(calendarIncomeDtoList);
+
+            //when
+            List<CalendarIncomeDto> getMonthlyIncomeCalendar
+                = incomeService.getMonthlyIncomeCalendar("test@naver.com",
+                LocalDate.of(2022, 10, 1),
+                LocalDate.of(2022, 10, 31));
+
+            //then
+            verify(incomeQueryRepository, times(1))
+                .getMonthlyIncomeCalendar(any(), any(), any());
+            assertEquals(getMonthlyIncomeCalendar.get(0).getItem(),
+                        calendarIncomeDtoList.get(0).getItem());
+        }
+
+        @Test
+        @DisplayName("실패 - 맴버 없음")
+        void getMonthlyIncomeCalendar_no_member() {
+            //given
+            given(memberRepository.findByEmail(any()))
+                .willReturn(Optional.empty());
+
+            //when
+            IncomeException exception = assertThrows(IncomeException.class,
+                () -> incomeService.getMonthlyIncomeCalendar("test@naver.com",
+                    LocalDate.of(2022, 10, 1),
+                    LocalDate.of(2022, 10, 31))
+            );
+
+            //then
+            assertEquals(exception.getErrorCode(), NO_MEMBER);
+        }
+
     }
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 달력 조회 API Dto 구성 : Diary Dto는 프론트단에서 개별 API로 호출하도록 할 예정 -> get과 post가 함께 진행되기 때문
- 달력 조회 API Service Layer2와 Repository 구현
- 달력 조회 API Service Layer2 테스트 코드 작성
- 달력 조회 API Service Layer1과 Controller 구현
- 달력 조회 API Service Layer1과 Controller 테스트 코드 작성

**TO-BE**

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 

```
{
  "year": 2022,
  "month": 10,
  "calendarIncomeDtoList": [
    {
      "incomeDt": "2022-10-01",
      "item": "쇼핑몰 만들기",
      "amount": 250000
    },
    {
      "incomeDt": "2022-10-25",
      "item": "10월 급여",
      "amount": 4000000
    },
    {
      "incomeDt": "2022-10-25",
      "item": "테슬라 배당금",
      "amount": 2000000
    }
  ],
  "calendarExpenseDtoList": [
    {
      "expenseDt": "2022-10-01",
      "item": "갈비탕",
      "amount": 10000
    },
    {
      "expenseDt": "2022-10-02",
      "item": "제육볶음",
      "amount": 10000
    },
    {
      "expenseDt": "2022-10-03",
      "item": "치킨",
      "amount": 13000
    },
    {
      "expenseDt": "2022-10-04",
      "item": "떡볶이",
      "amount": 6000
    },
    {
      "expenseDt": "2022-10-05",
      "item": "김밥",
      "amount": 2000
    }
  ]
}