### PR TITLE
Member 비밀번호 초기화 API

### DIFF
--- a/server/src/main/java/com/rezero/inandout/exception/errorcode/MemberErrorCode.java
+++ b/server/src/main/java/com/rezero/inandout/exception/errorcode/MemberErrorCode.java
@@ -53,6 +53,9 @@ public enum MemberErrorCode {
      * 비밀번호 오류
      */
     PASSWORD_NOT_MATCH("회원 비밀번호를 잘못 입력했습니다."),
+    CONFIRM_PASSWORD("비밀번호가 일치하지 않습니다. 두 비밀번호를 동일하게 입력하시길 바랍니다."),
+    RESET_PASSWORD_KEY_NOT_EXIST("비밀번호 초기화 코드가 존재하지 않습니다."),
+    RESET_PASSWORD_KEY_EXPIRED("비밀번호 초기화 코드의 유효기간이 만료됐습니다. 비밀번호 찾기를 처음부터 다시 진행하시길 바랍니다."),
 
     /**
      * 로그인 오류

--- a/server/src/main/java/com/rezero/inandout/member/controller/MemberController.java
+++ b/server/src/main/java/com/rezero/inandout/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.rezero.inandout.member.model.FindPasswordMemberInput;
 import com.rezero.inandout.member.model.JoinMemberInput;
 import com.rezero.inandout.member.model.LoginMemberInput;
 import com.rezero.inandout.member.model.MemberDto;
+import com.rezero.inandout.member.model.ResetPasswordInput;
 import com.rezero.inandout.member.model.UpdateMemberInput;
 import com.rezero.inandout.member.model.WithdrawMemberInput;
 import com.rezero.inandout.member.service.MemberService;
@@ -117,7 +118,17 @@ public class MemberController {
         @ApiParam(value = "연락처 입력") @RequestBody FindPasswordMemberInput findPasswordMemberInput) {
         memberService.validatePhone(findPasswordMemberInput.getEmail(),
             findPasswordMemberInput.getPhone());
-        String message = "비밀번호 찾기 완료";
+        String message = "이메일로 비밀번호 초기화 링크를 전송했습니다.";
+        return new ResponseEntity(message, HttpStatus.OK);
+    }
+
+
+    @PostMapping("/password/email/phone/sending")
+    @ApiOperation(value = "비밀번호 초기화 API", notes = "이메일 인증을 완료하면 새롭게 비밀번호를 설정 가능하다.")
+    public ResponseEntity<?> resetPassword(HttpServletRequest request, @ApiParam(value = "새로운 비밀번호를 입력") @RequestBody ResetPasswordInput input){
+        String uuid = request.getParameter("id");
+        memberService.resetPassword(uuid, input);
+        String message = "비밀번호 초기화가 완료됐습니다.";
         return new ResponseEntity(message, HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/rezero/inandout/member/entity/Member.java
+++ b/server/src/main/java/com/rezero/inandout/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.rezero.inandout.member.entity;
 import com.rezero.inandout.domain.BaseEntity;
 import com.rezero.inandout.member.model.MemberStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -39,6 +40,6 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private MemberStatus status;
     private String resetPasswordKey;
-    private String resetPasswordLimitDt;
+    private LocalDateTime resetPasswordLimitDt;
     private String emailAuthKey;
 }

--- a/server/src/main/java/com/rezero/inandout/member/model/ResetPasswordInput.java
+++ b/server/src/main/java/com/rezero/inandout/member/model/ResetPasswordInput.java
@@ -1,0 +1,19 @@
+package com.rezero.inandout.member.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordInput {
+
+    private String newPassword;
+    private String confirmNewPassword;
+
+}

--- a/server/src/main/java/com/rezero/inandout/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/rezero/inandout/member/repository/MemberRepository.java
@@ -18,4 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndPhone(String email, String phone);
 
     Optional<Member> findByEmailAuthKey(String emailAuthKey);
+
+    Optional<Member> findByResetPasswordKey (String resetPasswordKey);
+
 }

--- a/server/src/main/java/com/rezero/inandout/member/service/MemberService.java
+++ b/server/src/main/java/com/rezero/inandout/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.rezero.inandout.member.model.ChangePasswordInput;
 import com.rezero.inandout.member.model.JoinMemberInput;
 import com.rezero.inandout.member.model.LoginMemberInput;
 import com.rezero.inandout.member.model.MemberDto;
+import com.rezero.inandout.member.model.ResetPasswordInput;
 import com.rezero.inandout.member.model.UpdateMemberInput;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -50,6 +51,12 @@ public interface MemberService extends UserDetailsService {
 
 
     /**
+     * 회원 비밀번호 초기화 - 이전 비밀번호는 확인하지 않고 이메일 인증으로 대체
+     */
+    void resetPassword(String uuid, ResetPasswordInput input);
+
+
+    /**
      * 회원 조회
      */
     MemberDto getInfo(String email);
@@ -60,8 +67,9 @@ public interface MemberService extends UserDetailsService {
      */
     void updateInfo(String email, UpdateMemberInput input);
 
+
     /**
-     * 회원 비밀번호 수정
+     * 회원 비밀번호 수정 - 이전 비밀번호를 확인
      */
     void changePassword(String email, ChangePasswordInput input);
 

--- a/server/src/test/java/com/rezero/inandout/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/rezero/inandout/member/controller/MemberControllerTest.java
@@ -301,7 +301,7 @@ class MemberControllerTest {
 
         // given
         ResetPasswordInput input = ResetPasswordInput.builder().newPassword("abc123!@")
-            .confirmNewPassword("abc123!@#$%").build();
+            .confirmNewPassword("abc123!@").build();
         String inputToJson = mapper.writeValueAsString(input);
 
         // when
@@ -315,7 +315,6 @@ class MemberControllerTest {
         // then
         Mockito.verify(memberServiceImpl, times(1)).resetPassword(anyString(), captor.capture());
         assertEquals(input.getNewPassword(), captor.getValue().getNewPassword());
-
 
     }
 

--- a/server/src/test/java/com/rezero/inandout/member/controller/MemberControllerTest.java
+++ b/server/src/test/java/com/rezero/inandout/member/controller/MemberControllerTest.java
@@ -17,6 +17,7 @@ import com.rezero.inandout.member.model.FindPasswordMemberInput;
 import com.rezero.inandout.member.model.JoinMemberInput;
 import com.rezero.inandout.member.model.LoginMemberInput;
 import com.rezero.inandout.member.model.MemberStatus;
+import com.rezero.inandout.member.model.ResetPasswordInput;
 import com.rezero.inandout.member.model.UpdateMemberInput;
 import com.rezero.inandout.member.model.WithdrawMemberInput;
 import com.rezero.inandout.member.service.MemberServiceImpl;
@@ -87,8 +88,7 @@ class MemberControllerTest {
 
         // when
         mockMvc.perform(
-                post("/api/signup/sending?id=" + uuid)
-                    .contentType(MediaType.APPLICATION_JSON))
+                post("/api/signup/sending?id=" + uuid).contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk()).andDo(print());
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
@@ -275,9 +275,7 @@ class MemberControllerTest {
         // given
         Member member = Member.builder().email("egg@naver.com").password("abc123~!")
             .status(MemberStatus.ING).build();
-        WithdrawMemberInput input = WithdrawMemberInput.builder()
-            .password("abc123~!")
-            .build();
+        WithdrawMemberInput input = WithdrawMemberInput.builder().password("abc123~!").build();
         String withdrawInputToJson = mapper.writeValueAsString(input);
         User user = new User(member.getEmail(), member.getPassword(),
             AuthorityUtils.NO_AUTHORITIES);
@@ -285,15 +283,39 @@ class MemberControllerTest {
             null);
 
         // when
-        mockMvc.perform(MockMvcRequestBuilders
-            .delete("/api/member/info").contentType(MediaType.APPLICATION_JSON)
-            .content(withdrawInputToJson)
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/member/info")
+            .contentType(MediaType.APPLICATION_JSON).content(withdrawInputToJson)
             .principal(testingAuthenticationToken)).andExpect(status().isOk()).andDo(print());
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
         // then
         Mockito.verify(memberServiceImpl, times(1)).withdraw(anyString(), captor.capture());
         assertEquals(input.getPassword(), captor.getValue());
+
+    }
+
+
+    @Test
+    @DisplayName("회원 비밀번호 초기화")
+    void resetPassword() throws Exception {
+
+        // given
+        ResetPasswordInput input = ResetPasswordInput.builder().newPassword("abc123!@")
+            .confirmNewPassword("abc123!@#$%").build();
+        String inputToJson = mapper.writeValueAsString(input);
+
+        // when
+        String uuid = UUID.randomUUID().toString();
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/password/email/phone/sending?id=" + uuid)
+                .contentType(MediaType.APPLICATION_JSON).content(inputToJson))
+            .andExpect(status().isOk()).andDo(print());
+        ArgumentCaptor<ResetPasswordInput> captor = ArgumentCaptor.forClass(
+            ResetPasswordInput.class);
+
+        // then
+        Mockito.verify(memberServiceImpl, times(1)).resetPassword(anyString(), captor.capture());
+        assertEquals(input.getNewPassword(), captor.getValue().getNewPassword());
+
 
     }
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 비밀번호 초기화 API
- Input 클래스 ResetPasswordInput 추가
- Member 엔티티에 resetPasswordDt가 String으로 되어 있어서 LocalDateTime으로 수정 완료
- 비밀번호 찾기 메서드 validatePhone() 에 이메일 전송 코드 추가


**TO-BE**
- 회원 프로필 이미지 업로드

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
