### PR TITLE
Member OAuth 2.0 (2) Handler 구현

### DIFF
--- a/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationFailureHandler.java
+++ b/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationFailureHandler.java
@@ -1,0 +1,33 @@
+package com.rezero.inandout.configuration;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+@Slf4j
+public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException exception) throws IOException, ServletException {
+        String message = "로그인에 실패했습니다.";
+
+        if (exception instanceof InternalAuthenticationServiceException) {
+            message = exception.getMessage();
+        }
+
+        setUseForward(true);
+        setDefaultFailureUrl("/api/signin");
+
+        request.setAttribute("errorMessage", message);
+        super.onAuthenticationFailure(request, response, exception);
+
+    }
+
+}

--- a/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationSuccessHandler.java
+++ b/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.rezero.inandout.configuration;
 
+import com.rezero.inandout.member.repository.MemberRepository;
 import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -13,6 +14,7 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 @RequiredArgsConstructor
 public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private final MemberRepository memberRepository;        // 나중에 로그인 정보를 DB에 저장할 수도 있음
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationSuccessHandler.java
+++ b/server/src/main/java/com/rezero/inandout/configuration/UserAuthenticationSuccessHandler.java
@@ -1,0 +1,41 @@
+package com.rezero.inandout.configuration;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UserAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        String email = authentication.getName();
+        String frontLoginUrl = "https://re-zero-in-and-out.github.io/In-And-Out/calendar";
+
+        /*
+        LocalDate now = LocalDate.now();
+        LocalDate startDate = LocalDate.of(now.getYear(), now.getMonth(), 1);
+        LocalDate endDate = LocalDate.of(now.getYear(), now.getMonth(), now.lengthOfMonth());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        String start = startDate.format(formatter);
+        String end = endDate.format(formatter);
+        String mainUrl = "/api/calendar?startDt=" + start + "&endDt=" + end;
+        // ex) /api/calendar?start_dt=2022-11-01&end_dt=2022-11-30
+        */
+
+        log.info("[Member Login] member: " + email);
+        setDefaultTargetUrl(frontLoginUrl);
+        super.onAuthenticationSuccess(request, response, authentication);
+
+    }
+
+}

--- a/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
@@ -123,7 +123,7 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
     @Override
     public void logout() {
 
-        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+        if (SecurityContextHolder.getContext().getAuthentication() == null || SecurityContextHolder.getContext().getAuthentication().getName().equals("anonymousUser") ) {
             throw new MemberException(CANNOT_LOGOUT);
         }
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
- SuccessHandler, FailureHandler 구현
  - OAuth 로그인 시에만 적용
- SecurityConfig 수정
  - 로그인 성공 시, 프론트의 달력 페이지로 이동,
  - 로그아웃 성공 시, 프론트의 로그인 페이지로 이동
-  로그아웃 예외 처리 조건 추가

**TO-BE**

### 테스트 
- [ ] 테스트 코드
- [x] API 테스트 
