### PR TITLE
Member validation 수정

### DIFF
--- a/server/src/main/java/com/rezero/inandout/configuration/oauth/PrincipalOauth2UserService.java
+++ b/server/src/main/java/com/rezero/inandout/configuration/oauth/PrincipalOauth2UserService.java
@@ -35,12 +35,14 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
         Optional<Member> optionalMember;
         oauthMember.setOauthUsername(input.getOauthUsername());
 
+        /*
         optionalMember = memberRepository.findByPhone(input.getPhone());
         if (optionalMember.isPresent()) {
             oauthMember.setPhone(null);
         } else {
             oauthMember.setPhone(input.getPhone());
         }
+        */
 
         optionalMember = memberRepository.findByNickName(input.getNickName());
         if (optionalMember.isPresent()) {
@@ -77,9 +79,10 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
             if (!optionalMember.isPresent()) {
 
-                oauthMemberInput = validateOauthInput(oauthMemberInput);
+               // oauthMemberInput = validateOauthInput(oauthMemberInput);
                 member = Member.builder()
-                    .email(oauthUsername).nickName(oauthMemberInput.getNickName())
+                    .email(oauthUsername)
+                    .nickName(oauthUsername)
                     .phone(oauthMemberInput.getPhone())
                     .role(MemberRole.ROLE_OAUTH_MEMBER)
                     .memberS3ImageKey("")
@@ -113,10 +116,11 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
             if (!optionalMember.isPresent()) {
 
-                oauthMemberInput = validateOauthInput(oauthMemberInput);
+                //oauthMemberInput = validateOauthInput(oauthMemberInput);
 
                 member = Member.builder()
-                    .email(oauthUsername).nickName(oauthMemberInput.getNickName())
+                    .email(oauthUsername)
+                    .nickName(oauthUsername)
                     .phone(oauthMemberInput.getPhone()).gender(naverUserInfo.getGender())
                     .role(MemberRole.ROLE_OAUTH_MEMBER)
                     .memberS3ImageKey("")

--- a/server/src/main/java/com/rezero/inandout/configuration/oauth/PrincipalOauth2UserService.java
+++ b/server/src/main/java/com/rezero/inandout/configuration/oauth/PrincipalOauth2UserService.java
@@ -28,32 +28,6 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
 
 
-    public OauthMemberInput validateOauthInput(OauthMemberInput input) {
-
-        OauthMemberInput oauthMember = OauthMemberInput.builder().build();
-        String oauthUsername = input.getProvider() + "_" + input.getProviderId();
-        Optional<Member> optionalMember;
-        oauthMember.setOauthUsername(input.getOauthUsername());
-
-        /*
-        optionalMember = memberRepository.findByPhone(input.getPhone());
-        if (optionalMember.isPresent()) {
-            oauthMember.setPhone(null);
-        } else {
-            oauthMember.setPhone(input.getPhone());
-        }
-        */
-
-        optionalMember = memberRepository.findByNickName(input.getNickName());
-        if (optionalMember.isPresent()) {
-            oauthMember.setNickName(oauthUsername);
-        } else {
-            oauthMember.setNickName(input.getNickName());
-        }
-
-        return oauthMember;
-    }
-
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
@@ -70,16 +44,10 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
             String oauthUsername = provider + "_" + providerId;
             String encPwd = bCryptPasswordEncoder.encode(oauthUsername);
 
-            oauthMemberInput.setProvider(provider);
-            oauthMemberInput.setProviderId(providerId);
-            oauthMemberInput.setOauthUsername(oauthUsername);
-            oauthMemberInput.setNickName(googleUserInfo.getName());
-
             Optional<Member> optionalMember = memberRepository.findByEmail(oauthUsername);
 
             if (!optionalMember.isPresent()) {
 
-               // oauthMemberInput = validateOauthInput(oauthMemberInput);
                 member = Member.builder()
                     .email(oauthUsername)
                     .nickName(oauthUsername)
@@ -106,22 +74,15 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
             String oauthUsername = provider + "_" + providerId;
             String encPwd = bCryptPasswordEncoder.encode(oauthUsername);
 
-            oauthMemberInput.setProvider(provider);
-            oauthMemberInput.setProviderId(providerId);
-            oauthMemberInput.setOauthUsername(oauthUsername);
-            oauthMemberInput.setNickName(naverUserInfo.getNickname());
-            oauthMemberInput.setPhone(naverUserInfo.getPhone());
-
             Optional<Member> optionalMember = memberRepository.findByEmail(oauthUsername);
 
             if (!optionalMember.isPresent()) {
 
-                //oauthMemberInput = validateOauthInput(oauthMemberInput);
-
                 member = Member.builder()
                     .email(oauthUsername)
                     .nickName(oauthUsername)
-                    .phone(oauthMemberInput.getPhone()).gender(naverUserInfo.getGender())
+                    .phone(naverUserInfo.getPhone())
+                    .gender(naverUserInfo.getGender())
                     .role(MemberRole.ROLE_OAUTH_MEMBER)
                     .memberS3ImageKey("")
                     .status(MemberStatus.ING)

--- a/server/src/main/java/com/rezero/inandout/exception/errorcode/MemberErrorCode.java
+++ b/server/src/main/java/com/rezero/inandout/exception/errorcode/MemberErrorCode.java
@@ -11,7 +11,6 @@ public enum MemberErrorCode {
      * 회원가입 - 이미 존재하는 이메일, 휴대폰, 닉네임 오류, 탈퇴 / 정지 회원
      */
     EMAIL_EXIST("이미 가입된 이메일입니다. 가입된 이메일로 로그인 하시길 바랍니다."),
-    PHONE_EXIST("동일한 휴대폰 번호가 존재합니다. 다른 번호를 입력하세요."),
     NICKNAME_EXIST("동일한 닉네임이 존재합니다. 다른 닉네임을 입력하세요"),
     WITHDRAWAL_MEMBER_CANNOT_JOIN("이미 탈퇴한 아이디(이메일)입니다. 다른 이메일로 회원 가입하시길 바랍니다."),
     STOP_MEMBER_CANNOT_JOIN("정지된 회원입니다. 관리자에게 문의 바랍니다."),

--- a/server/src/main/java/com/rezero/inandout/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/rezero/inandout/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByPhone(String phone);
+//    Optional<Member> findByPhone(String phone);
 
     Optional<Member> findByNickName(String email);
 

--- a/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
@@ -16,7 +16,6 @@ import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PASSWORD_N
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PASSWORD_NOT_CONTAIN_DIGIT_AND_SPECIAL;
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PASSWORD_NOT_CONTAIN_SPECIAL;
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PASSWORD_NOT_MATCH;
-import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PHONE_EXIST;
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.PHONE_NOT_EXIST;
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.REQ_MEMBER_CANNOT_JOIN;
 import static com.rezero.inandout.exception.errorcode.MemberErrorCode.RESET_PASSWORD_KEY_EXPIRED;
@@ -157,11 +156,6 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
             throw new MemberException(EMAIL_EXIST);
         }
 
-//        existsMember = memberRepository.findByPhone(input.getPhone());
-//        if (existsMember.isPresent()) {
-//            throw new MemberException(PHONE_EXIST);
-//        }
-
         existsMember = memberRepository.findByNickName(input.getNickName());
         if (existsMember.isPresent()) {
             throw new MemberException(NICKNAME_EXIST);
@@ -251,11 +245,7 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
 
 // front 테스트 버전 ex) http://localhost:3000/In-And-Out/password_reset/sending?id=068e4252-2f68-45c3-9d7c-4ff5d02760a5
         String text = "<p>안녕하세요. In And Out 입니다.</p><p>아래 링크를 누르시면 회원 가입이 완료됩니다.</p>"
-            + "<div><a href='http://"
-            + ec2IpAddress
-            + ":3000"
-            + "/signup_check/sending?id="
-            + uuid
+            + "<div><a href='http://" + ec2IpAddress + ":3000" + "/signup_check/sending?id=" + uuid
             + "'>가입 완료</a></div>";
         mailComponent.send(input.getEmail(), subject, text);
 
@@ -381,7 +371,6 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
     public void updateInfo(String email, UpdateMemberInput input, MultipartFile file) {
 
         Member member = memberRepository.findByEmail(email).get();
-        String previousUsedPhone = member.getPhone();
         String previousUsedNickname = member.getNickName();
 
         if (input.getNickName().contains(" ") || input.getPhone().contains(" ") || input.getGender()
@@ -389,15 +378,8 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
             throw new MemberException(CONTAINS_BLANK);
         }
 
-        String inputPhone = input.getPhone();
         String inputNickname = input.getNickName();
 
-//        if (!previousUsedPhone.equals(inputPhone)) {
-//            Optional<Member> existPhoneMember = memberRepository.findByPhone(inputPhone);
-//            if (existPhoneMember.isPresent()) {
-//                throw new MemberException(PHONE_EXIST);
-//            }
-//        }
 
         if (!previousUsedNickname.equals(inputNickname)) {
             Optional<Member> existNicknameMember = memberRepository.findByNickName(inputNickname);

--- a/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
+++ b/server/src/main/java/com/rezero/inandout/member/service/impl/MemberServiceImpl.java
@@ -157,10 +157,10 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
             throw new MemberException(EMAIL_EXIST);
         }
 
-        existsMember = memberRepository.findByPhone(input.getPhone());
-        if (existsMember.isPresent()) {
-            throw new MemberException(PHONE_EXIST);
-        }
+//        existsMember = memberRepository.findByPhone(input.getPhone());
+//        if (existsMember.isPresent()) {
+//            throw new MemberException(PHONE_EXIST);
+//        }
 
         existsMember = memberRepository.findByNickName(input.getNickName());
         if (existsMember.isPresent()) {
@@ -391,12 +391,13 @@ public class MemberServiceImpl extends DefaultOAuth2UserService implements Membe
 
         String inputPhone = input.getPhone();
         String inputNickname = input.getNickName();
-        if (!previousUsedPhone.equals(inputPhone)) {
-            Optional<Member> existPhoneMember = memberRepository.findByPhone(inputPhone);
-            if (existPhoneMember.isPresent()) {
-                throw new MemberException(PHONE_EXIST);
-            }
-        }
+
+//        if (!previousUsedPhone.equals(inputPhone)) {
+//            Optional<Member> existPhoneMember = memberRepository.findByPhone(inputPhone);
+//            if (existPhoneMember.isPresent()) {
+//                throw new MemberException(PHONE_EXIST);
+//            }
+//        }
 
         if (!previousUsedNickname.equals(inputNickname)) {
             Optional<Member> existNicknameMember = memberRepository.findByNickName(inputNickname);

--- a/server/src/test/java/com/rezero/inandout/member/service/MemberServiceImplTest.java
+++ b/server/src/test/java/com/rezero/inandout/member/service/MemberServiceImplTest.java
@@ -257,39 +257,10 @@ class MemberServiceImplTest {
             exception.getErrorCode().getDescription());
 
     }
-/*
-    @Test
-    @DisplayName("회원 정보 수정(같은 폰번호가 존재하는 경우) - 실패 (2)")
-    void updateInfo_fail_sameNickName() {
 
-        // given
-        Member memberA = Member.builder().email("egg@naver.com").address("서울특별시")
-            .phone("010-2222-0000").birth(LocalDate.from(LocalDate.of(2000, 9, 30))).gender("남")
-            .nickName("강동원").password("abc!@#12").build();
-        given(memberRepository.findByEmail(any())).willReturn(Optional.of(memberA));
-
-        Member memberB = Member.builder().email("ogh@naver.com").address("인천광역시")
-            .phone("010-9999-0000").birth(LocalDate.from(LocalDate.of(1998, 9, 30))).gender("남")
-            .nickName("소지섭").password("abc!@#12").build();
-        given(memberRepository.findByPhone(any())).willReturn(Optional.of(memberB));
-
-        UpdateMemberInput input = UpdateMemberInput.builder().address("강원도").nickName("강동원")
-            .phone("010-9999-0000").birth(LocalDate.now()).gender("여")
-            .address("강원도").build();
-
-        // when
-        MemberException exception = assertThrows(MemberException.class,
-            () -> memberService.updateInfo(memberB.getEmail(), input, any()));
-
-        // then
-        assertEquals(MemberErrorCode.PHONE_EXIST.getDescription(),
-            exception.getErrorCode().getDescription());
-
-    }
-*/
 
     @Test
-    @DisplayName("회원 정보 수정(같은 닉네임이 존재하는 경우) - 실패(3)")
+    @DisplayName("회원 정보 수정(같은 닉네임이 존재하는 경우) - 실패(2)")
     void updateInfo_fail_samePhoneNumber() {
 
         // given

--- a/server/src/test/java/com/rezero/inandout/member/service/MemberServiceImplTest.java
+++ b/server/src/test/java/com/rezero/inandout/member/service/MemberServiceImplTest.java
@@ -257,7 +257,7 @@ class MemberServiceImplTest {
             exception.getErrorCode().getDescription());
 
     }
-
+/*
     @Test
     @DisplayName("회원 정보 수정(같은 폰번호가 존재하는 경우) - 실패 (2)")
     void updateInfo_fail_sameNickName() {
@@ -286,7 +286,7 @@ class MemberServiceImplTest {
             exception.getErrorCode().getDescription());
 
     }
-
+*/
 
     @Test
     @DisplayName("회원 정보 수정(같은 닉네임이 존재하는 경우) - 실패(3)")


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 회원 정책을 phone번호 중복을 허용하지 않았는데 허용을 변경
- oauthUser에 대해 email, nickname을 모두 provider + providerId 로 통일
- oauthUser에 대해 유효성 검증하는 메서드 삭제  (중복 체크를 없애서 강제로 회원 가입 가능)
- phone 중복 실패 테스트 삭제

**TO-BE**

### 테스트 
- [x] 테스트 코드
- [x] API 테스트 
